### PR TITLE
[feat] Use producer name and sequence number as fallback key in Key_Shared implementation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadata.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryAndMetadata.java
@@ -55,6 +55,9 @@ public class EntryAndMetadata implements Entry {
                 return metadata.getOrderingKey();
             } else if (metadata.hasPartitionKey()) {
                 return metadata.getPartitionKey().getBytes(StandardCharsets.UTF_8);
+            } else if (metadata.hasProducerName() && metadata.hasSequenceId()) {
+                String fallbackKey = metadata.getProducerName() + "-" + metadata.getSequenceId();
+                return fallbackKey.getBytes(StandardCharsets.UTF_8);
             }
         }
         return "NONE_KEY".getBytes(StandardCharsets.UTF_8);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -327,11 +328,11 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "data")
-    public void testNonKeySendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(
+    public void testNoKeySendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(
         String topicType,
         boolean enableBatch
     ) throws PulsarClientException {
-        String topic = topicType + "://public/default/key_shared_none_key-" + UUID.randomUUID();
+        String topic = topicType + "://public/default/key_shared_no_key-" + UUID.randomUUID();
 
         @Cleanup
         Consumer<Integer> consumer1 = createConsumer(topic);
@@ -351,13 +352,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                     .send();
         }
 
-        receive(Lists.newArrayList(consumer1, consumer2, consumer3));
+        receiveAndCheckDistribution(Lists.newArrayList(consumer1, consumer2, consumer3), 100);
     }
 
     @Test(dataProvider = "batch")
-    public void testNonKeySendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector(boolean enableBatch)
+    public void testNoKeySendAndReceiveWithHashRangeExclusiveStickyKeyConsumerSelector(boolean enableBatch)
             throws PulsarClientException {
-        String topic = "persistent://public/default/key_shared_none_key_exclusive-" + UUID.randomUUID();
+        String topic = "persistent://public/default/key_shared_no_key_exclusive-" + UUID.randomUUID();
 
         @Cleanup
         Consumer<Integer> consumer1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
@@ -374,21 +375,32 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         @Cleanup
         Producer<Integer> producer = createProducer(topic, enableBatch);
 
+        int consumer1ExpectMessages = 0;
+        int consumer2ExpectMessages = 0;
+        int consumer3ExpectMessages = 0;
+
         for (int i = 0; i < 100; i++) {
             producer.newMessage()
                     .value(i)
                     .send();
+
+            String fallbackKey = producer.getProducerName() + "-" + producer.getLastSequenceId();
+            int slot = Murmur3_32Hash.getInstance().makeHash(fallbackKey.getBytes())
+                    % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+            if (slot <= 20000) {
+                consumer1ExpectMessages++;
+            } else if (slot <= 40000) {
+                consumer2ExpectMessages++;
+            } else {
+                consumer3ExpectMessages++;
+            }
         }
-        int slot = Murmur3_32Hash.getInstance().makeHash("NONE_KEY".getBytes())
-                % KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+
         List<KeyValue<Consumer<Integer>, Integer>> checkList = new ArrayList<>();
-        if (slot <= 20000) {
-            checkList.add(new KeyValue<>(consumer1, 100));
-        } else if (slot <= 40000) {
-            checkList.add(new KeyValue<>(consumer2, 100));
-        } else {
-            checkList.add(new KeyValue<>(consumer3, 100));
-        }
+        checkList.add(new KeyValue<>(consumer1, consumer1ExpectMessages));
+        checkList.add(new KeyValue<>(consumer2, consumer2ExpectMessages));
+        checkList.add(new KeyValue<>(consumer3, consumer3ExpectMessages));
+
         receiveAndCheck(checkList);
     }
 
@@ -1725,19 +1737,17 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     private void receiveAndCheck(List<KeyValue<Consumer<Integer>, Integer>> checkList) throws PulsarClientException {
         Map<Consumer, Set<String>> consumerKeys = new HashMap<>();
         for (KeyValue<Consumer<Integer>, Integer> check : checkList) {
-            if (check.getValue() % 2 != 0) {
-                throw new IllegalArgumentException();
-            }
+            Consumer<Integer> consumer = check.getKey();
             int received = 0;
             Map<String, Message<Integer>> lastMessageForKey = new HashMap<>();
             for (Integer i = 0; i < check.getValue(); i++) {
-                Message<Integer> message = check.getKey().receive();
+                Message<Integer> message = consumer.receive();
                 if (i % 2 == 0) {
-                    check.getKey().acknowledge(message);
+                    consumer.acknowledge(message);
                 }
                 String key = message.hasOrderingKey() ? new String(message.getOrderingKey()) : message.getKey();
                 log.info("[{}] Receive message key: {} value: {} messageId: {}",
-                    check.getKey().getConsumerName(), key, message.getValue(), message.getMessageId());
+                        consumer.getConsumerName(), key, message.getValue(), message.getMessageId());
                 // check messages is order by key
                 if (lastMessageForKey.get(key) == null) {
                     Assert.assertNotNull(message);
@@ -1746,8 +1756,8 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
                         .compareTo(lastMessageForKey.get(key).getValue()) > 0);
                 }
                 lastMessageForKey.put(key, message);
-                consumerKeys.putIfAbsent(check.getKey(), new HashSet<>());
-                consumerKeys.get(check.getKey()).add(key);
+                consumerKeys.putIfAbsent(consumer, new HashSet<>());
+                consumerKeys.get(consumer).add(key);
                 received++;
             }
             Assert.assertEquals(check.getValue().intValue(), received);
@@ -1756,12 +1766,12 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             // messages not acked, test redelivery
             lastMessageForKey = new HashMap<>();
             for (int i = 0; i < redeliveryCount; i++) {
-                Message<Integer> message = check.getKey().receive();
+                Message<Integer> message = consumer.receive();
                 received++;
-                check.getKey().acknowledge(message);
+                consumer.acknowledge(message);
                 String key = message.hasOrderingKey() ? new String(message.getOrderingKey()) : message.getKey();
                 log.info("[{}] Receive redeliver message key: {} value: {} messageId: {}",
-                        check.getKey().getConsumerName(), key, message.getValue(), message.getMessageId());
+                        consumer.getConsumerName(), key, message.getValue(), message.getMessageId());
                 // check redelivery messages is order by key
                 if (lastMessageForKey.get(key) == null) {
                     Assert.assertNotNull(message);
@@ -1773,16 +1783,16 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             }
             Message noMessages = null;
             try {
-                noMessages = check.getKey().receive(100, TimeUnit.MILLISECONDS);
+                noMessages = consumer.receive(100, TimeUnit.MILLISECONDS);
             } catch (PulsarClientException ignore) {
             }
             Assert.assertNull(noMessages, "redeliver too many messages.");
             Assert.assertEquals((check.getValue() + redeliveryCount), received);
         }
         Set<String> allKeys = new HashSet<>();
-        consumerKeys.forEach((k, v) -> v.forEach(key -> {
+        consumerKeys.forEach((k, v) -> v.stream().filter(Objects::nonNull).forEach(key -> {
             assertTrue(allKeys.add(key),
-                "Key "+ key +  "is distributed to multiple consumers." );
+                "Key " + key + " is distributed to multiple consumers." );
         }));
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1186,11 +1186,13 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     static final byte[] NONE_KEY = "NONE_KEY".getBytes(StandardCharsets.UTF_8);
     protected byte[] peekMessageKey(Message<?> msg) {
         byte[] key = NONE_KEY;
-        if (msg.hasKey()) {
-            key = msg.getKeyBytes();
-        }
         if (msg.hasOrderingKey()) {
             key = msg.getOrderingKey();
+        } else if (msg.hasKey()) {
+            key = msg.getKeyBytes();
+        } else if (msg.getProducerName() != null) {
+            String fallbackKey = msg.getProducerName() + "-" + msg.getSequenceId();
+            key = fallbackKey.getBytes(StandardCharsets.UTF_8);
         }
         return key;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1979,6 +1979,9 @@ public class Commands {
                     return Base64.getDecoder().decode(metadata.getPartitionKey());
                 }
                 return metadata.getPartitionKey().getBytes(StandardCharsets.UTF_8);
+            } else if (metadata.hasProducerName() && metadata.hasSequenceId()) {
+                String fallbackKey = metadata.getProducerName() + "-" + metadata.getSequenceId();
+                return fallbackKey.getBytes(StandardCharsets.UTF_8);
             }
         } catch (Throwable t) {
             log.error("[{}] [{}] Failed to peek sticky key from the message metadata", topic, subscription, t);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
@@ -98,9 +98,11 @@ public class CommandsTest {
     public void testPeekStickyKey() {
         String message = "msg-1";
         String partitionedKey = "key1";
+        String producerName = "testProducer";
+        int sequenceId = 1;
         MessageMetadata messageMetadata2 = new MessageMetadata()
-                .setSequenceId(1)
-                .setProducerName("testProducer")
+                .setSequenceId(sequenceId)
+                .setProducerName(producerName)
                 .setPartitionKey(partitionedKey)
                 .setPartitionKeyB64Encoded(false)
                 .setPublishTime(System.currentTimeMillis());
@@ -113,16 +115,28 @@ public class CommandsTest {
         // test 64 encoded
         String partitionedKey2 = Base64.getEncoder().encodeToString("key2".getBytes(UTF_8));
         MessageMetadata messageMetadata = new MessageMetadata()
-                .setSequenceId(1)
-                .setProducerName("testProducer")
+                .setSequenceId(sequenceId)
+                .setProducerName(producerName)
                 .setPartitionKey(partitionedKey2)
                 .setPartitionKeyB64Encoded(true)
                 .setPublishTime(System.currentTimeMillis());
         ByteBuf byteBuf2 = serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, messageMetadata,
                 Unpooled.copiedBuffer(message.getBytes(UTF_8)));
         byte[] bytes2 = Commands.peekStickyKey(byteBuf2, "topic-2", "sub-2");
-        String key2 = Base64.getEncoder().encodeToString(bytes2);;
+        String key2 = Base64.getEncoder().encodeToString(bytes2);
         Assert.assertEquals(partitionedKey2, key2);
         ReferenceCountUtil.safeRelease(byteBuf2);
+        // test fallback key if no key given in message metadata
+        String fallbackPartitionedKey = producerName + "-" + sequenceId;
+        MessageMetadata messageMetadataWithoutKey = new MessageMetadata()
+                .setSequenceId(sequenceId)
+                .setProducerName(producerName)
+                .setPublishTime(System.currentTimeMillis());
+        ByteBuf byteBuf3 = serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, messageMetadataWithoutKey,
+                Unpooled.copiedBuffer(message.getBytes(UTF_8)));
+        byte[] bytes3 = Commands.peekStickyKey(byteBuf3, "topic-3", "sub-3");
+        String key3 = new String(bytes3);
+        Assert.assertEquals(fallbackPartitionedKey, key3);
+        ReferenceCountUtil.safeRelease(byteBuf3);
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/MessagingBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/MessagingBase.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -150,11 +151,11 @@ public abstract class MessagingBase extends PulsarTestSuite {
                 }
             }
         }
-        // Make sure key will not be distributed to multiple consumers
+        // Make sure key will not be distributed to multiple consumers (except null key)
         Set<String> allKeys = Sets.newHashSet();
-        consumerKeys.forEach((k, v) -> v.forEach(key -> {
+        consumerKeys.forEach((k, v) -> v.stream().filter(Objects::nonNull).forEach(key -> {
             assertTrue(allKeys.add(key),
-                    "Key "+ key +  "is distributed to multiple consumers" );
+                    "Key " + key + " is distributed to multiple consumers" );
         }));
         assertEquals(messagesReceived.size(), messagesToReceive);
     }


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #23212

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Taken from issue:

The Key_Shared implementation expects that the incoming message contain either a key/keyBytes or orderingKey.
If the key isn't set, the implementation will use the bytes of the NONE_KEY string as the key. This could be a surprise to users since the implications of not setting the key is not documented.

The problem that this causes is that all messages without a key will handled by a single consumer. If any of these messages is in redelivery, it will cause all message delivery to be blocked.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- Updated all parts where NONE_KEY was used as a default: Prefer 1) ordering key, 2) partition key, 3) new fallback key derived from producer name and sequence number, 4) NONE_KEY

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Updated KeySharedSubscriptionTest to verify that messages are distributed evenly among consumers and based on the producer-derived key if no ordering/partition key is given
- Added test case to CommandsTest for the new fallback key

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
